### PR TITLE
Update ignore files for EB Deploy

### DIFF
--- a/.ebignore
+++ b/.ebignore
@@ -1,0 +1,1 @@
+yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ frontend/build/asset-*
 
 ############## Jekyll Stuff ##################
 .sass-cache/
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml


### PR DESCRIPTION
If you try to run `eb deploy` using the command line without a `.ebignore` file it runs a `git archive` command, which ignores git repositories. With this file the git repo is included and the Dockerfile will not fail on `git submodule update`. 