### PR TITLE
Add authentication to /odk/data/submissions/

### DIFF
--- a/api/odk/controllers/get-formlist.js
+++ b/api/odk/controllers/get-formlist.js
@@ -1,5 +1,8 @@
 var xml2js = require('xml2js');
-var parser = new xml2js.Parser({explicitArray: false, attrkey: "attributes"});
+var parser = new xml2js.Parser({
+  explicitArray: false,
+  attrkey: "attributes"
+});
 var createFormList = require('openrosa-formlist');
 var getFormUrls = require('../helpers/get-form-urls');
 var settings = require('../../../settings');
@@ -9,70 +12,68 @@ var fs = require('fs');
  * Searches for XForm XML Files on the file system and
  * returns valid OpenRosa formList XML.
  */
-module.exports = function (req, res, next) {
-    var options = {
-        headers: {
-            'User-Agent': 'OpenMapKitServer'
-        },
-        baseUrl: req.protocol + '://' + req.headers.host + '/omk/data/forms'
+module.exports = function(req, res, next) {
+  var options = {
+    headers: {'User-Agent': 'OpenMapKitServer'},
+    baseUrl: req.protocol + '://' + req.headers.host + '/omk/data/forms'
+  };
+
+  // Look for "json" query param
+  var json = req.query.json || false;
+  var formId = req.query.formid;
+
+  return getFormUrls(options, function(err, formUrls) {
+    if (err) {
+      return next(err);
+    }
+
+    var formListOptions = {
+      headers: options.headers,
+      manifestUrl: `${req.protocol}://${req.headers.host}/omk/odk/manifest/\${formId}.xml`
     };
 
-    // Look for "json" query param
-    var json = req.query.json || false;
-    var formId = req.query.formid;
-
-    return getFormUrls(options, function (err, formUrls) {
-        if (err) {
-          return next(err);
+    return createFormList(formUrls, formListOptions, function(err, xml) {
+      if (err) {
+        // patch around openrosa-formlist not passing proper Errors
+        if (!(err instanceof Error)) {
+          err = new Error(err);
         }
 
-        var formListOptions = {
-            headers: options.headers,
-            manifestUrl: `${req.protocol}://${req.headers.host}/omk/odk/manifest/\${formId}.xml`
-        };
+        return next(err);
+      }
 
-        return createFormList(formUrls, formListOptions, function (err, xml) {
-            if (err) {
-              // patch around openrosa-formlist not passing proper Errors
-              if (!(err instanceof Error)) {
-                err = new Error(err);
-              }
+      // Default is XML, but JSON is an option
+      if (json) {
+        return parser.parseString(xml, function(err, result) {
+          if (result === undefined) {
+            res.status(200).json(null);
+          } else {
+            if (typeof result.xforms.xform == "object") {
 
-              return next(err);
+              // make sure xform is an array
+              var xformarr = result.xforms.xform.length === undefined ? [result.xforms.xform] : result.xforms.xform;
+
+              addSubmissionCount(xformarr, function(xformJson) {
+                if (formId) {
+                  result.xforms.xform = xformJson.filter(function(arr) {
+                    return arr.formID == formId;
+                  });
+                } else {
+                  result.xforms.xform = xformJson;
+                }
+                res.status(200).json(result);
+              });
+            } else {
+              res.status(200).json(null);
             }
-
-            // Default is XML, but JSON is an option
-            if (json) {
-                return parser.parseString(xml, function (err, result) {
-                    if (result === undefined) {
-                        res.status(200).json(null);
-                    } else {
-                        if (typeof result.xforms.xform == "object") {
-
-                            // make sure xform is an array
-                            var xformarr = result.xforms.xform.length === undefined ? [result.xforms.xform] : result.xforms.xform;
-
-                            addSubmissionCount(xformarr, function (xformJson) {
-                                if(formId){
-                                    result.xforms.xform = xformJson.filter(function(arr){
-                                        return arr.formID == formId;
-                                    });
-                                } else {
-                                    result.xforms.xform = xformJson;
-                                }
-                                res.status(200).json(result);
-                            });
-                        } else {
-                            res.status(200).json(null);
-                        }
-                    }
-                });
-            }
-
-            res.set('content-type', 'text/xml; charset=utf-8');
-            res.status(200).send(xml);
+          }
         });
+      }
+
+      res.set('content-type', 'text/xml; charset=utf-8');
+      res.status(200).send(xml);
     });
+  });
 };
 
 /**
@@ -80,25 +81,25 @@ module.exports = function (req, res, next) {
  * @param xformJson
  */
 function addSubmissionCount(xformJson, cb) {
-    // loop through each form
-    var count = 0;
-    xformJson.forEach(function (form) {
-        // add totalSubmission to xformJson object
-        form.totalSubmissions = 0;
-        // loop thourgh each forms submission directory
-        fs.readdir(settings.dataDir + '/submissions/' + form.formID, function (err, files) {
-            if (err) {
-                console.log('Form: ' + form.formID + ' has no submissions.');
-            } else {
-                // add number of files as total submissions
-                form.totalSubmissions = directoryCount(files);
-                // return xformsJson after looping through all forms
-            }
-            if (++count === xformJson.length) {
-                cb(xformJson);
-            }
-        });
-    })
+  // loop through each form
+  var count = 0;
+  xformJson.forEach(function(form) {
+    // add totalSubmission to xformJson object
+    form.totalSubmissions = 0;
+    // loop thourgh each forms submission directory
+    fs.readdir(settings.dataDir + '/submissions/' + form.formID, function(err, files) {
+      if (err) {
+        console.log('Form: ' + form.formID + ' has no submissions.');
+      } else {
+        // add number of files as total submissions
+        form.totalSubmissions = directoryCount(files);
+        // return xformsJson after looping through all forms
+      }
+      if (++count === xformJson.length) {
+        cb(xformJson);
+      }
+    });
+  });
 }
 
 /**
@@ -108,12 +109,12 @@ function addSubmissionCount(xformJson, cb) {
  * @param files
  */
 function directoryCount(files) {
-    var count = 0;
-    for (var i = 0, len = files.length; i < len; i++) {
-        var f = files[i];
-        // dont show hidden files like .DS_Store and files with extensions
-        if (f.indexOf('.') > -1) continue;
-        ++count;
-    }
-    return count;
+  var count = 0;
+  for (var i = 0, len = files.length; i < len; i++) {
+    var f = files[i];
+    // dont show hidden files like .DS_Store and files with extensions
+    if (f.indexOf('.') > -1) continue;
+    ++count;
+  }
+  return count;
 }

--- a/api/odk/odk-data.js
+++ b/api/odk/odk-data.js
@@ -1,0 +1,48 @@
+var router = require('express').Router({ mergeParams: true });
+var fs = require('fs');
+var settings = require('../../settings');
+
+
+function getFile(req, res, next) {
+  var filePath;
+  if (req.params.prefix === 'forms') {
+    filePath = `${settings.dataDir}/${req.params.prefix}/${req.params.file}`;
+  }
+  if (req.params.prefix === 'submissions') {
+    filePath = `${settings.dataDir}/${req.params.prefix}/${req.params.formName}/${req.params.submission}/${req.params.file}`;
+  }
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      console.log(err);
+      return res.status(err.status).json(err);
+    }
+    if (req.params.file.endsWith('csv')) {
+      return res.status(200).set('Content-Type', 'text/csv').send(data);
+    }
+    if (req.params.file.endsWith('json')) {
+      return res.status(200).json(JSON.parse(data));
+    }
+    if (req.params.file.endsWith('xml') || req.params.file.endsWith('osm')) {
+      return res.set('Content-Type', 'application/xml').status(200).send(data);
+    }
+    if (req.params.file.endsWith('xlsx')) {
+      return res.set(
+        'Content-Type',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+      ).status(200).send(data);
+    }
+  });
+}
+
+var disableAuth = process.env.DISABLE_AUTH == 1 || process.env.DISABLE_AUTH == 'true';
+if (disableAuth) {
+  router.route('/:prefix/:formName/:submission/:file').get(getFile);
+} else {
+  var adminDVPermission = require('permission')(['admin', 'data-viewer']);
+  var adminPermission = require('permission')(['admin']);
+  router.route('/:prefix/:formName/:submission/:file').get(adminDVPermission, getFile);
+}
+// /forms/* URL endpoint
+router.route('/:prefix/:file').get(getFile);
+
+module.exports = router;

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ var LocalStrategy = require('passport-local').Strategy;
 
 var odkOpenRosa = require('./api/odk/odk-openrosa-routes');
 var odkAggregate = require('./api/odk/odk-aggregate-routes');
+var odkData = require('./api/odk/odk-data');
 var deployments = require('./api/deployments/deployment-routes');
 var error = require('./api/odk/controllers/error-handler');
 var pkg = require('./package');
@@ -178,9 +179,8 @@ app.use('/omk/odk', odkAggregate);
 app.use('/omk/deployments', deployments);
 
 // Public Data & Static Assets
-app.use('/omk/data', express.static(settings.dataDir));
-app.use('/omk/data', directory(settings.dataDir));
-app.use('/omk/data/submissions', adminDVPermission);
+app.use('/omk/data/submissions', auth);
+app.use('/omk/data', odkData);
 app.use('/omk/pages', express.static(settings.pagesDir));
 app.use('/omk/pages', directory(settings.pagesDir));
 // Handle errors


### PR DESCRIPTION
* The authentication is required only to `/odk/data/submissions/`. The `/odk/data/forms/` will be publicly accessible.
* The navigation on the folders is not possible any more.
* It's possible to disable the need of authentication with the env variable `DISABLE_AUTH=1`

@mojodna Let me know if it has some impact on POSM.